### PR TITLE
New :Cargo commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.2
+
+* Add CargoClean, CargoDoc, CargoNew, and CargoUpdate
+
 ## 0.0.1
 
 * Allow running dispatch implictly, removing the dependency. This makes it possible

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Simple vim command bindings to quickly run cargo stuff from vim.
 
 ## Commands Available, mapping with their Cargo equivalant:
 
+* CargoBench
 * CargoBuild
+* CargoClean
+* CargoDoc
+* CargoNew
 * CargoRun
 * CargoTest
-* CargoBench
-* CargoNew
+* CargoUpdate
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Simple vim command bindings to quickly run cargo stuff from vim.
 * CargoRun
 * CargoTest
 * CargoBench
+* CargoNew
 
 ## Usage
 

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -14,7 +14,7 @@ com! CargoDoc call cargo#run('doc')
 com! CargoRun call cargo#run('run')
 com! CargoTest call cargo#run('test')
 com! CargoUpdate call cargo#run('update')
-com! -complete=file -nargs=+ CargoNew call cargo#run('new ' . string(<q-args>))
+com! -complete=file -nargs=1 CargoNew call cargo#run('new ' . string(<q-args>))
 
 func! cargo#run(cmd)
   let s:cargo_command = substitute(g:cargo_command, "{cmd}", a:cmd, 'g')

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -14,7 +14,7 @@ com! CargoDoc call cargo#run('doc')
 com! CargoRun call cargo#run('run')
 com! CargoTest call cargo#run('test')
 com! CargoUpdate call cargo#run('update')
-com! -complete=file -nargs=1 CargoNew call cargo#run('new ' . string(<q-args>))
+com! -complete=file -nargs=+ CargoNew call cargo#run('new ' . <q-args>)
 
 func! cargo#run(cmd)
   let s:cargo_command = substitute(g:cargo_command, "{cmd}", a:cmd, 'g')

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -8,10 +8,10 @@ if !exists('g:cargo_command')
 endif
 
 com! CargoBuild call cargo#run('build')
-com! CargoRun   call cargo#run('run')
-com! CargoTest  call cargo#run('test')
+com! CargoRun call cargo#run('run')
+com! CargoTest call cargo#run('test')
 com! CargoBench call cargo#run('bench')
-com! CargoNew   call cargo#run('new')
+com! -bar -bang -complete=file -nargs=+ CargoNew call cargo#run('new' . string(<q-args>))
 
 func! cargo#run(cmd)
   let s:cargo_command = substitute(g:cargo_command, "{cmd}", a:cmd, 'g')

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -8,9 +8,10 @@ if !exists('g:cargo_command')
 endif
 
 com! CargoBuild call cargo#run('build')
-com! CargoRun call cargo#run('run')
-com! CargoTest call cargo#run('test')
+com! CargoRun   call cargo#run('run')
+com! CargoTest  call cargo#run('test')
 com! CargoBench call cargo#run('bench')
+com! CargoNew   call cargo#run('new')
 
 func! cargo#run(cmd)
   let s:cargo_command = substitute(g:cargo_command, "{cmd}", a:cmd, 'g')

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -7,11 +7,14 @@ if !exists('g:cargo_command')
   let g:cargo_command = "!cargo {cmd}"
 endif
 
+com! CargoBench call cargo#run('bench')
 com! CargoBuild call cargo#run('build')
+com! CargoClean call cargo#run('clean')
+com! CargoDoc call cargo#run('doc')
 com! CargoRun call cargo#run('run')
 com! CargoTest call cargo#run('test')
-com! CargoBench call cargo#run('bench')
-com! -bar -bang -complete=file -nargs=+ CargoNew call cargo#run('new' . string(<q-args>))
+com! CargoUpdate call cargo#run('update')
+com! -complete=file -nargs=+ CargoNew call cargo#run('new ' . string(<q-args>))
 
 func! cargo#run(cmd)
   let s:cargo_command = substitute(g:cargo_command, "{cmd}", a:cmd, 'g')


### PR DESCRIPTION
Adding new commands. `:CargoNew` accepts multiple args, to allow for `--bin` and `--vcs`.