### PR TITLE
Add super versions of cargo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ Simple vim command bindings to quickly run cargo stuff from vim.
 
 ## Commands Available, mapping with their Cargo equivalant:
 
-* CargoBuild
-* CargoRun
-* CargoTest
-* CargoBench
+* CargoBuild, CargoBuildSuper
+* CargoRun, CargoRunSuper
+* CargoTest, CargoTestSuper
+* CargoBench, CargoBenchSuper
+
+The *super* versions of these functions detects the outer-most `Cargo.toml` file -
+useful to build the outer project when developing nested crates.
+
 
 ## Installation
 

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -10,12 +10,56 @@ if !exists('g:cargo_command')
   let g:cargo_command = "make {cmd}"
 endif
 
-com! CargoBuild call cargo#run('build')
-com! CargoRun call cargo#run('run')
-com! CargoTest call cargo#run('test')
-com! CargoBench call cargo#run('bench')
+com! CargoBuild      call cargo#run('build', 0)
+com! CargoBuildSuper call cargo#run('build', 1)
 
-func! cargo#run(cmd)
+com! CargoRun      call cargo#run('run', 0)
+com! CargoRunSuper call cargo#run('run', 1)
+
+com! CargoTest      call cargo#run('test', 0)
+com! CargoTestSuper call cargo#run('test', 1)
+
+com! CargoBench      call cargo#run('bench', 0)
+com! CargoBenchSuper call cargo#run('bench', 1)
+
+func! cargo#run(cmd, is_super)
+  " Clear quickfix and redraw so we see when new content is available.
+  call setqflist([])
+  redraw!
+
+  " Find Cargo.toml, 'is_super' finds the outer most (super-project).
+  let filename = 'Cargo.toml'
+  let parent_orig = expand('%:p:h')
+  let filepath_found = ""
+  let parent = parent_orig
+  while 1
+    let parent_prev = parent
+    let parent_file = parent.'/'.filename
+    if filereadable(parent_file)
+      let filepath_found = parent_file
+      if !a:is_super
+        break
+      endif
+    endif
+    let parent = fnamemodify(parent, ':h')
+    if parent == parent_prev
+      break
+    endif
+  endwhile
+  if filepath_found == ""
+    echom 'Cargo: "'.filename.'" not found in "'.parent_orig.'"'
+    return
+  endif
+
   let s:cargo_command = substitute(g:cargo_command, "{cmd}", a:cmd, 'g')
-  execute s:cargo_command
+
+  " Give some indication we're doing something
+  echom "Cargo..."
+
+  " Use silent so we don't need to keep closing the errors,
+  " (quickfix window auto-opens in current config).
+  execute ':silent ' s:cargo_command . ' --manifest-path ' . filepath_found
+
+  " Clear
+  echon "\r"
 endf


### PR DESCRIPTION
This searches up the parent directories for the 'outer' most Cargo.toml,
useful for building the entire project from a nested crate.

----

Note that I had problems using this plugin as-is.

The paths as reported in the quickfix window were relative to the `Cargo.toml`, not the `pwd`.

While the build worked, cycling through the errors didn't open the proper files.

This PR passes the `Cargo.toml` location to cargo, and adds support for building the parent-most Cargo.toml, which I needed when using creates in subdirectories of other crates.
